### PR TITLE
Adapt services to latest ta4j API changes

### DIFF
--- a/src/main/java/com/dnobretech/tradingbotcrypto/service/StrategyService.java
+++ b/src/main/java/com/dnobretech/tradingbotcrypto/service/StrategyService.java
@@ -5,13 +5,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.ta4j.core.*;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
-import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.indicators.ema.EMAIndicator;
 import org.ta4j.core.indicators.RSIIndicator;
 import org.ta4j.core.indicators.bollinger.*;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
-import org.ta4j.core.rules.OverboughtRule;
-import org.ta4j.core.rules.OversoldRule;
+import org.ta4j.core.rules.OverIndicatorRule;
+import org.ta4j.core.rules.UnderIndicatorRule;
 
 
 import java.time.ZoneOffset;
@@ -33,7 +33,8 @@ public class StrategyService {
                     c.getHigh().doubleValue(),
                     c.getLow().doubleValue(),
                     c.getClose().doubleValue(),
-                    c.getVolume().doubleValue());
+                    c.getVolume().doubleValue(),
+                    0d);
         }
         return series;
     }
@@ -56,8 +57,8 @@ public class StrategyService {
         BollingerBandsStandardDeviationIndicator sd = new BollingerBandsStandardDeviationIndicator(close, bbPeriod);
         BollingerBandsUpperIndicator upper = new BollingerBandsUpperIndicator(middle, sd);
         BollingerBandsLowerIndicator lower = new BollingerBandsLowerIndicator(middle, sd);
-        Rule entry = new OversoldRule(rsi, 30).and(new CrossedDownIndicatorRule(close, lower));
-        Rule exit = new OverboughtRule(rsi, 70).or(new CrossedUpIndicatorRule(close, upper));
+        Rule entry = new UnderIndicatorRule(rsi, 30).and(new CrossedDownIndicatorRule(close, lower));
+        Rule exit = new OverIndicatorRule(rsi, 70).or(new CrossedUpIndicatorRule(close, upper));
         return new BaseStrategy(entry, exit);
     }
 }


### PR DESCRIPTION
## Summary
- update strategy service imports and rules for ta4j 0.18
- use Position-based metrics and Instant timestamps in backtesting

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5edbddee8832fbd8a8eb8cf4ef878