### PR TITLE
Add global CORS filter to allow frontend access

### DIFF
--- a/src/main/java/com/dnobretech/tradingbotcrypto/config/CorsConfig.java
+++ b/src/main/java/com/dnobretech/tradingbotcrypto/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.dnobretech.tradingbotcrypto.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}


### PR DESCRIPTION
## Summary
- add global CORS filter allowing requests from http://localhost:5173

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b3f82550832fb64058aaab31146e