### PR TITLE
feat: add capital and position size to backtest

### DIFF
--- a/src/main/java/com/dnobretech/tradingbotcrypto/controller/BacktestController.java
+++ b/src/main/java/com/dnobretech/tradingbotcrypto/controller/BacktestController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 
+import java.math.BigDecimal;
 import java.util.List;
 
 
@@ -24,7 +25,9 @@ public class BacktestController {
     public BacktestDtos.BacktestResult run(@RequestBody BacktestDtos.BacktestRequest req){
         List<Candle> candles = repo.findLastN(req.symbol(), req.interval(), req.limit()==null?500:req.limit());
         java.util.Collections.reverse(candles);
-        return backtestService.run(candles, req.strategy(), n(req.fast(),12), n(req.slow(),26), n(req.rsi(),14), n(req.bb(),20));
+        BigDecimal initialCapital = req.initialCapital()==null?BigDecimal.valueOf(10000):req.initialCapital();
+        BigDecimal positionSize = req.positionSize()==null?BigDecimal.ONE:req.positionSize();
+        return backtestService.run(candles, req.strategy(), n(req.fast(),12), n(req.slow(),26), n(req.rsi(),14), n(req.bb(),20), initialCapital, positionSize);
     }
 
 

--- a/src/main/java/com/dnobretech/tradingbotcrypto/dto/BacktestDtos.java
+++ b/src/main/java/com/dnobretech/tradingbotcrypto/dto/BacktestDtos.java
@@ -6,7 +6,18 @@ import java.util.List;
 
 
 public class BacktestDtos {
-    public record BacktestRequest(String symbol, String interval, Integer limit, String strategy, Integer fast, Integer slow, Integer rsi, Integer bb) {}
+    public record BacktestRequest(
+            String symbol,
+            String interval,
+            Integer limit,
+            String strategy,
+            Integer fast,
+            Integer slow,
+            Integer rsi,
+            Integer bb,
+            BigDecimal initialCapital,
+            BigDecimal positionSize
+    ) {}
     public record TradePoint(Instant time, String type, BigDecimal price) {}
     public record EquityPoint(Instant time, BigDecimal value) {}
     public record Metrics(BigDecimal totalReturnPct, BigDecimal maxDrawdownPct, BigDecimal winRatePct, BigDecimal profitFactor, int trades) {}


### PR DESCRIPTION
## Summary
- allow specifying initialCapital and positionSize in BacktestRequest
- propagate new parameters through BacktestController and BacktestService
- compute equity from initial capital and scale PnL by position size

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cd8d6890832fa4b327b83ebad732