### PR TITLE
feat: ingest candles by date range

### DIFF
--- a/src/main/java/com/dnobretech/tradingbotcrypto/controller/IngestionController.java
+++ b/src/main/java/com/dnobretech/tradingbotcrypto/controller/IngestionController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 
+import java.time.Instant;
 import java.util.Map;
 
 
@@ -17,11 +18,20 @@ public class IngestionController {
 
 
     public record Req(String symbol, String interval, Integer limit){}
+    public record RangeReq(String symbol, String interval, String start, String end){}
 
 
     @PostMapping
     public Map<String,Object> ingest(@RequestBody Req req){
         int saved = ingestionService.ingestRecent(req.symbol(), req.interval(), req.limit()==null?500:req.limit());
+        return Map.of("saved", saved);
+    }
+
+    @PostMapping("/range")
+    public Map<String,Object> ingestRange(@RequestBody RangeReq req){
+        Instant start = Instant.parse(req.start());
+        Instant end = Instant.parse(req.end());
+        int saved = ingestionService.ingestRange(req.symbol(), req.interval(), start, end);
         return Map.of("saved", saved);
     }
 }


### PR DESCRIPTION
## Summary
- allow BinanceClient to request klines by optional start and end time
- ingest candles over a date range with new service method
- add controller endpoint for range-based ingestion

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ce59bc74832f81546302f6a6444b