### PR TITLE
Add MACD+RSI strategy

### DIFF
--- a/src/main/java/com/dnobretech/tradingbotcrypto/controller/BacktestController.java
+++ b/src/main/java/com/dnobretech/tradingbotcrypto/controller/BacktestController.java
@@ -27,7 +27,7 @@ public class BacktestController {
         java.util.Collections.reverse(candles);
         BigDecimal initialCapital = req.initialCapital()==null?BigDecimal.valueOf(10000):req.initialCapital();
         BigDecimal positionSize = req.positionSize()==null?BigDecimal.ONE:req.positionSize();
-        return backtestService.run(candles, req.strategy(), n(req.fast(),12), n(req.slow(),26), n(req.rsi(),14), n(req.bb(),20), initialCapital, positionSize);
+        return backtestService.run(candles, req.strategy(), n(req.fast(),12), n(req.slow(),26), n(req.signal(),9), n(req.rsi(),14), n(req.bb(),20), initialCapital, positionSize);
     }
 
 

--- a/src/main/java/com/dnobretech/tradingbotcrypto/dto/BacktestDtos.java
+++ b/src/main/java/com/dnobretech/tradingbotcrypto/dto/BacktestDtos.java
@@ -11,8 +11,9 @@ public class BacktestDtos {
             String interval,
             Integer limit,
             String strategy,
-            Integer fast,
-            Integer slow,
+            Integer fast,   // EMA/MACD fast period
+            Integer slow,   // EMA/MACD slow period
+            Integer signal, // MACD signal period
             Integer rsi,
             Integer bb,
             BigDecimal initialCapital,

--- a/src/main/java/com/dnobretech/tradingbotcrypto/service/BacktestService.java
+++ b/src/main/java/com/dnobretech/tradingbotcrypto/service/BacktestService.java
@@ -21,11 +21,13 @@ public class BacktestService {
     private final StrategyService strategyService;
 
 
-    public BacktestDtos.BacktestResult run(List<Candle> candles, String strategyName, int fast, int slow, int rsi, int bb, BigDecimal initialCapital, BigDecimal positionSize){
+    public BacktestDtos.BacktestResult run(List<Candle> candles, String strategyName, int fast, int slow, int signal, int rsi, int bb, BigDecimal initialCapital, BigDecimal positionSize){
         BarSeries series = strategyService.toSeries(candles);
-        Strategy strategy = "rsi_boll".equals(strategyName) ?
-                strategyService.rsiBoll(series, rsi, bb) :
-                strategyService.emaCross(series, fast, slow);
+        Strategy strategy = switch (strategyName) {
+            case "rsi_boll" -> strategyService.rsiBoll(series, rsi, bb);
+            case "macd_rsi" -> strategyService.macdRsi(series, fast, slow, signal, rsi);
+            default -> strategyService.emaCross(series, fast, slow);
+        };
 
 
         BarSeriesManager mgr = new BarSeriesManager(series);

--- a/src/main/java/com/dnobretech/tradingbotcrypto/service/StrategyService.java
+++ b/src/main/java/com/dnobretech/tradingbotcrypto/service/StrategyService.java
@@ -10,6 +10,7 @@ import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.averages.EMAIndicator;
 import org.ta4j.core.indicators.averages.SMAIndicator;
 import org.ta4j.core.indicators.statistics.StandardDeviationIndicator;
+import org.ta4j.core.indicators.MACDIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 import org.ta4j.core.rules.OverIndicatorRule;
@@ -66,6 +67,17 @@ public class StrategyService {
         BollingerBandsLowerIndicator lower = new BollingerBandsLowerIndicator(middle, sd);
         Rule entry = new UnderIndicatorRule(rsi, 30).and(new CrossedDownIndicatorRule(close, lower));
         Rule exit = new OverIndicatorRule(rsi, 70).or(new CrossedUpIndicatorRule(close, upper));
+        return new BaseStrategy(entry, exit);
+    }
+
+
+    public Strategy macdRsi(BarSeries series, int fast, int slow, int signal, int rsiPeriod){
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        MACDIndicator macd = new MACDIndicator(close, fast, slow);
+        EMAIndicator macdSignal = new EMAIndicator(macd, signal);
+        RSIIndicator rsi = new RSIIndicator(close, rsiPeriod);
+        Rule entry = new CrossedUpIndicatorRule(macd, macdSignal).and(new UnderIndicatorRule(rsi, 30));
+        Rule exit = new CrossedDownIndicatorRule(macd, macdSignal).or(new OverIndicatorRule(rsi, 70));
         return new BaseStrategy(entry, exit);
     }
 }


### PR DESCRIPTION
## Summary
- add MACD + RSI strategy implementation
- allow backtest API to run `macd_rsi` strategy and accept MACD signal period
- document MACD period parameters in backtest request DTO

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d1f31b18832fadecd211a72b0089